### PR TITLE
build: hado lint disable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
+# hadolint ignore=DL3007
 FROM thinca/vim:latest
 
 # reviewdog
 ENV REVIEWDOG_VERSION=v0.17.0
 
+# hadolint ignore=DL4006
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
+# hadolint ignore=DL3018
 RUN apk add --no-cache git bash && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
* latest version work correct
* "SHELL bash set -o pipefail" This setting is not available
* bash do not lock version
